### PR TITLE
Razor custom view model breaks with Layout

### DIFF
--- a/src/extensions/Wyam.Razor/WyamDocumentPhase.cs
+++ b/src/extensions/Wyam.Razor/WyamDocumentPhase.cs
@@ -26,7 +26,6 @@ namespace Wyam.Razor
 
             // Get the current model type, replacing default of dynamic with IDocument
             string modelType = ModelDirective.GetModelType(documentNode);
-            modelType = modelType == "dynamic" ? "IDocument" : modelType;
 
             // Set the base page type and perform default model type substitution here
             ClassDeclarationIntermediateNode classDeclaration =

--- a/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
+++ b/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
@@ -167,7 +167,6 @@ namespace Wyam.Razor.Tests
 
                 // Then
                 results.Single().Content.ShouldBe("<p>3</p>");
-
             }
 
             [Test]

--- a/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
+++ b/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using NUnit.Framework;
 using Wyam.Common.Documents;
 using Wyam.Common.IO;
@@ -16,6 +12,7 @@ using Wyam.Testing.Documents;
 using Wyam.Testing.Execution;
 using Wyam.Testing.IO;
 using Shouldly;
+using Wyam.Common.Configuration;
 
 namespace Wyam.Razor.Tests
 {
@@ -151,6 +148,50 @@ namespace Wyam.Razor.Tests
 
                 // Then
                 results.Single().Content.ShouldBe("<p>3</p>");
+            }
+
+            [Test]
+            public void AlternateModelFromDelegate()
+            {
+                // Given
+                Engine engine = new Engine();
+                IExecutionContext context = GetExecutionContext(engine);
+                IDocument document = GetDocument("C:/Temp/temp.txt", @"@model IList<int>
+<p>@Model.Count</p>");
+                IList<int> model = new[] { 1, 2, 3 };
+                Razor razor = new Razor()
+                    .WithModel((doc, ctx) => model);
+
+                // When
+                List<IDocument> results = razor.Execute(new[] { document }, context).ToList();
+
+                // Then
+                results.Single().Content.ShouldBe("<p>3</p>");
+
+            }
+
+            [Test]
+            public void AlternateModelFromDelegateWithViewStartAndLayoutFile()
+            {
+                // Given
+                Engine engine = new Engine();
+                IExecutionContext context = GetExecutionContext(engine);
+                IDocument document = GetDocument(
+                    "/ViewStartAndLayout/Test.cshtml",
+                    @"@model int[]
+<p>This is a test</p>");
+                IList<int> model = new[] { 1, 2, 3 };
+                Razor razor = new Razor()
+                    .WithModel((doc, ctx) => model); ;
+
+                // When
+                List<IDocument> results = razor.Execute(new[] { document }, context).ToList();
+
+                // Then
+                results.Single().Content.ShouldBe(
+                    @"LAYOUT2
+<p>This is a test</p>",
+                    StringCompareShould.IgnoreLineEndings);
             }
 
             [Test]

--- a/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
+++ b/tests/extensions/Wyam.Razor.Tests/RazorFixture.cs
@@ -182,7 +182,7 @@ namespace Wyam.Razor.Tests
 <p>This is a test</p>");
                 IList<int> model = new[] { 1, 2, 3 };
                 Razor razor = new Razor()
-                    .WithModel((doc, ctx) => model); ;
+                    .WithModel((doc, ctx) => model);
 
                 // When
                 List<IDocument> results = razor.Execute(new[] { document }, context).ToList();


### PR DESCRIPTION
Setting a custom model for a Razor view while also using a layout and viewstart file causes an error similar to this:

> Exception while processing document /ViewStartAndLayout/Test.cshtml in module unknown: The model item passed into the ViewDataDictionary is of type 'System.Int32[]', but this ViewDataDictionary instance requires a model item of type 'Wyam.Common.Documents.IDocument'.

There are two new tests in this PR. There was no test yet for setting the view model from a delegate and the second test covers the error.

The fix I did doesn't seem to break any tests which seems, which makes me wonder why that line was there in the first place.

A bit of background: I'm working on a Wyam module that pulls in content from Kontent headless CMS. The client for that CMS supports strong typed content models which is something I'm also hoping to support with this module for Wyam.